### PR TITLE
Исправил размеры картинки в подвале

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -318,6 +318,7 @@ button {
 .promo__image {
   align-self: end;
   justify-self: end;
+  width: 100%;
 }
 
 .promo__button {


### PR DESCRIPTION
В сафари картинка в подвале становится очень большой, если не указывать ей размеры

<img width="1440" alt="Снимок экрана 2024-02-11 в 10 30 58" src="https://github.com/Yandex-Practicum/pindie-startkit/assets/54995327/b25f148a-48f2-4821-a3d2-22ccf240132d">
